### PR TITLE
add new EncryptionType, add new KeyCrypterFactory

### DIFF
--- a/core/src/main/java/org/bitcoinj/crypto/EncryptedData.java
+++ b/core/src/main/java/org/bitcoinj/crypto/EncryptedData.java
@@ -16,6 +16,8 @@
 
 package org.bitcoinj.crypto;
 
+import org.bitcoinj.protobuf.wallet.Protos;
+
 import java.util.Arrays;
 import java.util.Objects;
 
@@ -29,10 +31,12 @@ import java.util.Objects;
 public final class EncryptedData {
     public final byte[] initialisationVector;
     public final byte[] encryptedBytes;
+    public final Protos.Wallet.EncryptionType encryptionType;
 
-    public EncryptedData(byte[] initialisationVector, byte[] encryptedBytes) {
+    public EncryptedData(byte[] initialisationVector, byte[] encryptedBytes, Protos.Wallet.EncryptionType encryptionType) {
         this.initialisationVector = Arrays.copyOf(initialisationVector, initialisationVector.length);
         this.encryptedBytes = Arrays.copyOf(encryptedBytes, encryptedBytes.length);
+        this.encryptionType = encryptionType;
     }
 
     @Override

--- a/core/src/main/java/org/bitcoinj/crypto/KeyCrypterFactory.java
+++ b/core/src/main/java/org/bitcoinj/crypto/KeyCrypterFactory.java
@@ -1,0 +1,7 @@
+package org.bitcoinj.crypto;
+
+import org.bitcoinj.protobuf.wallet.Protos;
+
+public interface KeyCrypterFactory {
+    KeyCrypter createKeyCrypter();
+}

--- a/core/src/main/java/org/bitcoinj/crypto/KeyCrypterScrypt.java
+++ b/core/src/main/java/org/bitcoinj/crypto/KeyCrypterScrypt.java
@@ -187,7 +187,9 @@ public class KeyCrypterScrypt implements KeyCrypter {
             final int length1 = cipher.processBytes(plainBytes, 0, plainBytes.length, encryptedBytes, 0);
             final int length2 = cipher.doFinal(encryptedBytes, length1);
 
-            return new EncryptedData(iv, Arrays.copyOf(encryptedBytes, length1 + length2));
+            return new EncryptedData(iv,
+                    Arrays.copyOf(encryptedBytes, length1 + length2),
+                    EncryptionType.ENCRYPTED_SCRYPT_AES);
         } catch (Exception e) {
             throw new KeyCrypterException("Could not encrypt bytes.", e);
         }

--- a/core/src/main/java/org/bitcoinj/wallet/BasicKeyChain.java
+++ b/core/src/main/java/org/bitcoinj/wallet/BasicKeyChain.java
@@ -360,7 +360,8 @@ public class BasicKeyChain implements EncryptableKeyChain {
                     .setEncryptedPrivateKey(ByteString.copyFrom(data.encryptedBytes))
                     .setInitialisationVector(ByteString.copyFrom(data.initialisationVector)));
             // We don't allow mixing of encryption types at the moment.
-            checkState(item.getEncryptionType() == Protos.Wallet.EncryptionType.ENCRYPTED_SCRYPT_AES);
+            checkState(item.getEncryptionType() == Protos.Wallet.EncryptionType.ENCRYPTED_SCRYPT_AES ^
+                    item.getEncryptionType() == Protos.Wallet.EncryptionType.ENCRYPTED_KEYSTORE_AES);
             proto.setType(Protos.Key.Type.ENCRYPTED_SCRYPT_AES);
         } else {
             final byte[] secret = item.getSecretBytes();
@@ -416,7 +417,8 @@ public class BasicKeyChain implements EncryptableKeyChain {
                         throw new UnreadableWalletException("Encrypted private key data missing");
                     Protos.EncryptedData proto = key.getEncryptedData();
                     EncryptedData e = new EncryptedData(proto.getInitialisationVector().toByteArray(),
-                            proto.getEncryptedPrivateKey().toByteArray());
+                            proto.getEncryptedPrivateKey().toByteArray(),
+                            keyCrypter.getUnderstoodEncryptionType());
                     ecKey = ECKey.fromEncrypted(e, keyCrypter, pub);
                 } else {
                     if (priv != null)

--- a/core/src/main/java/org/bitcoinj/wallet/DeterministicSeed.java
+++ b/core/src/main/java/org/bitcoinj/wallet/DeterministicSeed.java
@@ -262,7 +262,11 @@ public class DeterministicSeed implements EncryptableItem {
 
     @Override
     public Protos.Wallet.EncryptionType getEncryptionType() {
-        return Protos.Wallet.EncryptionType.ENCRYPTED_SCRYPT_AES;
+        if (encryptedMnemonicCode != null) {
+            return encryptedMnemonicCode.encryptionType;
+        } else {
+            return null;
+        }
     }
 
     @Nullable

--- a/core/src/main/proto/wallet.proto
+++ b/core/src/main/proto/wallet.proto
@@ -358,6 +358,7 @@ message Wallet {
   enum EncryptionType {
     UNENCRYPTED = 1;                 // All keys in the wallet are unencrypted
     ENCRYPTED_SCRYPT_AES = 2;        // All keys are encrypted with a passphrase based KDF of scrypt and AES encryption
+    ENCRYPTED_KEYSTORE_AES = 3;
   }
 
   required string network_identifier = 1; // the network used by this wallet

--- a/core/src/test/java/org/bitcoinj/crypto/ECKeyTest.java
+++ b/core/src/test/java/org/bitcoinj/crypto/ECKeyTest.java
@@ -29,6 +29,7 @@ import org.bitcoinj.core.Transaction;
 import org.bitcoinj.crypto.ECKey.ECDSASignature;
 import org.bitcoinj.crypto.internal.CryptoUtils;
 import org.bitcoinj.base.internal.FutureUtils;
+import org.bitcoinj.protobuf.wallet.Protos;
 import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
@@ -432,7 +433,9 @@ public class ECKeyTest {
 
         // Break the encrypted private key and check it is broken.
         byte[] badEncryptedPrivateKeyBytes = new byte[goodEncryptedPrivateKeyBytes.length];
-        encryptedPrivateKey = new EncryptedData(encryptedPrivateKey.initialisationVector, badEncryptedPrivateKeyBytes);
+        encryptedPrivateKey = new EncryptedData(encryptedPrivateKey.initialisationVector,
+                badEncryptedPrivateKeyBytes,
+                Protos.Wallet.EncryptionType.ENCRYPTED_SCRYPT_AES);
         ECKey badEncryptedKey = ECKey.fromEncrypted(encryptedPrivateKey, keyCrypter, originalUnencryptedKey.getPubKey());
         assertFalse("Key encryption is reversible with faulty encrypted bytes", ECKey.encryptionIsReversible(originalUnencryptedKey, badEncryptedKey, keyCrypter, keyCrypter.deriveKey(PASSWORD1)));
     }

--- a/core/src/test/java/org/bitcoinj/store/WalletProtobufSerializerTest.java
+++ b/core/src/test/java/org/bitcoinj/store/WalletProtobufSerializerTest.java
@@ -422,6 +422,18 @@ public class WalletProtobufSerializerTest {
         assertEquals(0, wallet5.getExtensions().size());
     }
 
+    /*@Test
+    public void encryptedWallet() throws Exception {
+        myWallet.encrypt("1");
+        Protos.Wallet proto = new WalletProtobufSerializer().walletToProto(myWallet);
+        try {
+            new WalletProtobufSerializer().readWallet(BitcoinNetwork.TESTNET, null, proto);
+            fail();
+        } catch (UnreadableWalletException e) {
+            assertTrue(e.getMessage().contains("mandatory"));
+        }
+    }*/
+
     @Test
     public void extensionsWithError() throws Exception {
         WalletExtension extension = new WalletExtension() {


### PR DESCRIPTION
This PR proposes the implementation of a KeyCrypterFactory which allows users of the library to import their own KeyCrypters using their own EncryptionTypes. Currently this only works by extending the KeyCrypterScrypt class.