### PR TITLE
Proposal for KeyCrypterFactory and new EncryptionType

### DIFF
--- a/core/src/main/java/org/bitcoinj/crypto/EncryptedData.java
+++ b/core/src/main/java/org/bitcoinj/crypto/EncryptedData.java
@@ -16,6 +16,8 @@
 
 package org.bitcoinj.crypto;
 
+import org.bitcoinj.protobuf.wallet.Protos;
+
 import java.util.Arrays;
 import java.util.Objects;
 
@@ -29,10 +31,12 @@ import java.util.Objects;
 public final class EncryptedData {
     public final byte[] initialisationVector;
     public final byte[] encryptedBytes;
+    public final Protos.Wallet.EncryptionType encryptionType;
 
-    public EncryptedData(byte[] initialisationVector, byte[] encryptedBytes) {
+    public EncryptedData(byte[] initialisationVector, byte[] encryptedBytes, Protos.Wallet.EncryptionType encryptionType) {
         this.initialisationVector = Arrays.copyOf(initialisationVector, initialisationVector.length);
         this.encryptedBytes = Arrays.copyOf(encryptedBytes, encryptedBytes.length);
+        this.encryptionType = encryptionType;
     }
 
     @Override

--- a/core/src/main/java/org/bitcoinj/crypto/KeyCrypterFactory.java
+++ b/core/src/main/java/org/bitcoinj/crypto/KeyCrypterFactory.java
@@ -1,0 +1,7 @@
+package org.bitcoinj.crypto;
+
+import org.bitcoinj.protobuf.wallet.Protos;
+
+public interface KeyCrypterFactory {
+    KeyCrypter createKeyCrypter();
+}

--- a/core/src/main/java/org/bitcoinj/crypto/KeyCrypterFactory.java
+++ b/core/src/main/java/org/bitcoinj/crypto/KeyCrypterFactory.java
@@ -1,7 +1,37 @@
+/*
+ * Copyright by the original author or authors.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.bitcoinj.crypto;
 
 import org.bitcoinj.protobuf.wallet.Protos;
 
+/**
+ * The {@code KeyCrypterFactory} interface defines a factory pattern for creating instances of {@code KeyCrypter}.
+ * This factory interface is utilized to abstract the creation process of {@code KeyCrypter} objects, allowing for
+ * flexible implementations of {@code KeyCrypterScrypt} subclasses that can be swapped easily without altering the 
+ * BitcoinJ code base.
+ */
 public interface KeyCrypterFactory {
+    /**
+     * Creates and returns a new instance of a {@code KeyCrypter}. The specific type and configuration of the
+     * {@code KeyCrypter} returned depend on the implementation of this factory. Each call to this method should
+     * return a new, independent instance of a {@code KeyCrypter}.
+     *
+     *
+     * @return a newly created instance of {@code KeyCrypter}.
+     */
     KeyCrypter createKeyCrypter();
 }

--- a/core/src/main/java/org/bitcoinj/crypto/KeyCrypterScrypt.java
+++ b/core/src/main/java/org/bitcoinj/crypto/KeyCrypterScrypt.java
@@ -187,7 +187,9 @@ public class KeyCrypterScrypt implements KeyCrypter {
             final int length1 = cipher.processBytes(plainBytes, 0, plainBytes.length, encryptedBytes, 0);
             final int length2 = cipher.doFinal(encryptedBytes, length1);
 
-            return new EncryptedData(iv, Arrays.copyOf(encryptedBytes, length1 + length2));
+            return new EncryptedData(iv,
+                    Arrays.copyOf(encryptedBytes, length1 + length2),
+                    EncryptionType.ENCRYPTED_SCRYPT_AES);
         } catch (Exception e) {
             throw new KeyCrypterException("Could not encrypt bytes.", e);
         }

--- a/core/src/main/java/org/bitcoinj/wallet/DeterministicSeed.java
+++ b/core/src/main/java/org/bitcoinj/wallet/DeterministicSeed.java
@@ -262,7 +262,13 @@ public class DeterministicSeed implements EncryptableItem {
 
     @Override
     public Protos.Wallet.EncryptionType getEncryptionType() {
-        return Protos.Wallet.EncryptionType.ENCRYPTED_SCRYPT_AES;
+        if (encryptedMnemonicCode != null) {
+            return encryptedMnemonicCode.encryptionType;
+        } else if (encryptedSeed != null) {
+            return encryptedSeed.encryptionType;
+        } else {
+            return null;
+        }
     }
 
     @Nullable

--- a/core/src/main/proto/wallet.proto
+++ b/core/src/main/proto/wallet.proto
@@ -89,8 +89,8 @@ message Key {
     /** Unencrypted - Original bitcoin secp256k1 curve */
     ORIGINAL = 1;
 
-    /** Encrypted with Scrypt and AES - Original bitcoin secp256k1 curve */
-    ENCRYPTED_SCRYPT_AES = 2;
+    /** Encrypted - Original bitcoin secp256k1 curve */
+    ENCRYPTED = 2;
 
     /**
     * Not really a key, but rather contains the mnemonic phrase for a deterministic key hierarchy in the private_key field.
@@ -358,6 +358,7 @@ message Wallet {
   enum EncryptionType {
     UNENCRYPTED = 1;                 // All keys in the wallet are unencrypted
     ENCRYPTED_SCRYPT_AES = 2;        // All keys are encrypted with a passphrase based KDF of scrypt and AES encryption
+    ENCRYPTED_KEYSTORE_AES = 3;      // All keys are encrypted KeyStore HW encryption
   }
 
   required string network_identifier = 1; // the network used by this wallet

--- a/core/src/test/java/org/bitcoinj/crypto/ECKeyTest.java
+++ b/core/src/test/java/org/bitcoinj/crypto/ECKeyTest.java
@@ -29,6 +29,7 @@ import org.bitcoinj.core.Transaction;
 import org.bitcoinj.crypto.ECKey.ECDSASignature;
 import org.bitcoinj.crypto.internal.CryptoUtils;
 import org.bitcoinj.base.internal.FutureUtils;
+import org.bitcoinj.protobuf.wallet.Protos;
 import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
@@ -432,7 +433,9 @@ public class ECKeyTest {
 
         // Break the encrypted private key and check it is broken.
         byte[] badEncryptedPrivateKeyBytes = new byte[goodEncryptedPrivateKeyBytes.length];
-        encryptedPrivateKey = new EncryptedData(encryptedPrivateKey.initialisationVector, badEncryptedPrivateKeyBytes);
+        encryptedPrivateKey = new EncryptedData(encryptedPrivateKey.initialisationVector,
+                badEncryptedPrivateKeyBytes,
+                Protos.Wallet.EncryptionType.ENCRYPTED_SCRYPT_AES);
         ECKey badEncryptedKey = ECKey.fromEncrypted(encryptedPrivateKey, keyCrypter, originalUnencryptedKey.getPubKey());
         assertFalse("Key encryption is reversible with faulty encrypted bytes", ECKey.encryptionIsReversible(originalUnencryptedKey, badEncryptedKey, keyCrypter, keyCrypter.deriveKey(PASSWORD1)));
     }


### PR DESCRIPTION
This PR proposes the implementation of a KeyCrypterFactory which allows users of the library to import their own KeyCrypters using their own EncryptionTypes. Currently this only works by extending the KeyCrypterScrypt class.

Change log:
- Add KeyCrypterFactory which can be set in WalletProtobufSerializer
- Add encryptionType field in EncryptedData
- Add Protos.Wallet.EncryptionType ENCRYPTED_KEYSTORE_AES in wallet.proto
- BasicKeyChain and DeterministicKeyChain: Check if one of the wallet encryption types is set
- DeterministicSeed: Return the encryptionType of the EncryptedData
- WalletProtobufSerializer: Use KeyCrypter provided by KeyCrypterFactory if the new encryption type ENCRYPTED_KEYSTORE_AES is defined in the protobuf